### PR TITLE
Updated datatable and jquery to get the latest security fixes.

### DIFF
--- a/academy_theme/templates/academy_theme/base--wildewidgets.html
+++ b/academy_theme/templates/academy_theme/base--wildewidgets.html
@@ -5,16 +5,14 @@
   {{ block.super }}
   <link rel="stylesheet" href="{% static 'wildewidgets/css/table_extra.css' %}">
   <link rel="stylesheet" href="{% static 'wildewidgets/css/wildewidgets.css' %}">
-  <link href="https://cdn.datatables.net/1.10.21/css/jquery.dataTables.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.datatables.net/v/dt/dt-2.1.4/date-1.5.3/datatables.min.css">
   <link rel="stylesheet" href="{% static 'wildewidgets/css/highlighting.css' %}">
 {% endblock %}
 
 {% block extra_header_js %}
   {{ block.super }}
   <script src="{% static 'wildewidgets/js/wildewidgets.js' %}"></script>
-  <script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.4/moment.min.js"></script>
-  <script src="https://cdn.datatables.net/plug-ins/1.10.21/sorting/datetime-moment.js"></script>
+  <script src="https://cdn.datatables.net/v/dt/dt-2.1.4/date-1.5.3/datatables.min.js"></script>
 {% endblock %}
 
 {% block title %}{{page_title}}{% endblock %}

--- a/academy_theme/templates/academy_theme/base.html
+++ b/academy_theme/templates/academy_theme/base.html
@@ -24,7 +24,7 @@
       <link rel="stylesheet" href="{{stylesheet}}">
     {% endfor %}
   {% endblock %}
-  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+  <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.0.0-beta16/dist/js/tabler.min.js"></script>
   {% block extra_header_js %}
     {# Override this in subtemplates to add additional javascript to the page. Remember to use defer. #}
@@ -118,7 +118,7 @@
     </footer>
   </div>
   <!-- jQuery first, then Popper.js, then Bootstrap JS, as specified by the Bootstrap docs. -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js" integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r" crossorigin="anonymous"></script>
   <script src="{% static 'academy_theme/js/theme.js' %}"></script>
   {% block extra_footer_js %}
     {% for package in extra_footer_js %}


### PR DESCRIPTION
Updated to Datatable 2 which supports jQuery 3.x and comes with it's own DateTime extension and no longer supports moment.js. Datatable has a CDN link builder to include their extensions, it will require overwriting the extra blocks for customization.

Popper.js for Bootstrap 5.2 and 5.3 was 2.11.6 and 2.11.8, so I went with the latest patch.

NOTE: If we update to Bootstrap to 5.3, there are some breaking changes that would affect django-wildewidgets. Navbar for one, no longer has the .navbar-dark class and uses a data attribute instead.

It seems that Datatable 2 works fine with the current django-wildewidgets, however I'm not using any additional extensions.